### PR TITLE
Support for React v18

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "lodash": "4.17.21"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || 17"
+    "react": "^16.8.6 || 17 || 18"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.172",


### PR DESCRIPTION
Installing this package in a React v18 project does not work, this should fix the issue.