### PR TITLE
Update index.ts to use useLayoutEffect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useLayoutEffect } from "react";
 import throttle from "lodash/fp/throttle";
 
 export interface useScrollSpyParams {
@@ -35,7 +35,7 @@ export default ({
     setActiveSection(currentSectionId);
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const scrollable = scrollingElement?.current ?? window;
     scrollable.addEventListener("scroll", handle);
 


### PR DESCRIPTION
Update hook to use useLayoutEffect
https://react.dev/reference/react/useLayoutEffect#usage
https://blog.saeloun.com/2022/07/28/difference-between-useeffect-and-useeffectlayout-hooks/

Using useEffect causes some unintended behaviour with other libraries